### PR TITLE
Add new Like and Display number of likes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,9 @@
 import './style.css';
+import icon from './assets/pageIcon.png';
+import { fetchApi } from './modules/Api.js';
+
+const headerIcon = document.querySelector('#pageIcon');
+headerIcon.src = icon;
+headerIcon.classList.add('icon');
+
+window.onload = fetchApi();

--- a/src/modules/Api.js
+++ b/src/modules/Api.js
@@ -1,3 +1,6 @@
+import { getLikeCount, handleLike } from './Likes.js';
+import countItems from './itemsCounter.js';
+
 const container = document.getElementById('cardContainer');
 const createCard = (json) => {
   // Created a Div with class card
@@ -21,6 +24,10 @@ const createCard = (json) => {
   likeBtn.innerHTML = '<i class="far fa-heart"></i>';
   likeBtn.id = json.id;
 
+  const likeCount = document.createElement('span');
+  likeCount.className = 'like-count';
+  likeCount.id = json.id;
+
   const commentBtn = document.createElement('button');
   commentBtn.className = 'comment-btn';
   commentBtn.textContent = 'Comment';
@@ -31,11 +38,19 @@ const createCard = (json) => {
   card.appendChild(title);
   card.appendChild(imgContainer);
   card.appendChild(likeBtn);
+  card.appendChild(likeCount);
   card.appendChild(commentBtn);
   container.appendChild(card);
-};
 
-// Fetching Api
+  likeBtn.addEventListener('click', () => {
+    handleLike(json.id);
+  });
+
+  // Call the function to retrieve and update the like count
+  getLikeCount(json.id);
+  countItems();
+};
+// eslint-disable-next-line import/no-mutable-exports
 let arr = [];
 const fetchApi = async () => {
   const response = await fetch('https://api.tvmaze.com/shows');
@@ -48,4 +63,4 @@ const fetchApi = async () => {
     });
   }
 };
-export default { fetchApi, arr };
+export { fetchApi, arr };

--- a/src/modules/Likes.js
+++ b/src/modules/Likes.js
@@ -1,0 +1,44 @@
+const likesId = 'https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/pEISiLJvLymH65NIR0wE/likes/';
+
+const countLikes = (data, itemId) => {
+  const result = data.filter((obj) => obj.item_id === itemId);
+  if (result) {
+    const likeBadge = document.getElementById(itemId);
+    likeBadge.textContent = `${result[0].likes} 🤍`;
+  }
+};
+const getLikeCount = async (itemId) => {
+  try {
+    // Send request to Involvement API
+    const response = await fetch(likesId);
+    const data = await response.json();
+    // Update the like count badge
+    const result = data.filter((obj) => obj.item_id === itemId);
+    if (result.length >= 1) {
+      countLikes(data, itemId);
+    }
+  } catch (error) {
+    // Handle Error
+  }
+};
+
+const handleLike = async (itemId) => {
+  try {
+    // Send request to Involvement API
+    await fetch(likesId, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        item_id: itemId,
+      }),
+    });
+    getLikeCount(itemId);
+    // Update Like count badge
+  } catch (error) {
+    // Error Handling
+  }
+};
+
+export { countLikes, getLikeCount, handleLike };

--- a/src/modules/itemsCounter.js
+++ b/src/modules/itemsCounter.js
@@ -1,0 +1,7 @@
+const countItems = () => {
+  const allCards = document.querySelectorAll('.card');
+  const itemsCount = document.querySelector('.items-counter');
+  itemsCount.innerHTML = allCards.length;
+};
+
+export default countItems;

--- a/src/style.css
+++ b/src/style.css
@@ -14,6 +14,136 @@ header {
   padding: 0 8%;
 }
 
+.card {
+  width: 350px;
+  border: 3px solid black;
+  border-radius: 10px;
+  margin: 10px;
+}
+
+.img-container {
+  height: 200px;
+  overflow: hidden;
+}
+
+img {
+  width: 100%;
+  object-fit: cover;
+}
+
+#cardContainer {
+  display: grid;
+  grid-template-columns: auto auto auto;
+  justify-content: space-evenly;
+  background: #eee;
+  gap: 50px 10px;
+  padding: 100px;
+  margin-bottom: -50px;
+}
+
+.iconDiv {
+  display: flex;
+  justify-content: center;
+}
+
+.icon {
+  width: 100px;
+}
+
+.headerList {
+  display: flex;
+  list-style: none;
+  gap: 50px;
+}
+
+.headerListItem {
+  font-size: 25px;
+}
+
+a {
+  text-decoration: none;
+}
+
+a:link,
+a:visited,
+a:hover,
+a:active {
+  color: #fff;
+}
+
+.like-btn,
+.comment-btn {
+  background-color: #a38500;
+  color: white;
+  border: none;
+  height: 50px;
+  padding: 10px 20px;
+  margin: 3px 3px;
+  font-size: 18px;
+  border-radius: 5px;
+}
+
+.comment-btn {
+  background-color: #2b70a8;
+}
+
+h3 {
+  text-align: center;
+  font-weight: bold;
+  font-size: 32px;
+}
+
+.movie {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.infoDiv {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 15px;
+  width: 360px;
+}
+
+.movieTitle {
+  font-weight: bold;
+  font-size: 30px;
+}
+
+.movieInfo {
+  font-size: 22px;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 300px;
+  height: 200px;
+  margin-bottom: 20px;
+  margin-top: 10px;
+}
+
+.fName,
+.fComment {
+  border: 1px solid #bbb;
+  border-radius: 3px;
+  padding-left: 5px;
+}
+
+.fName {
+  height: 24px;
+}
+
+.fComment {
+  font-family: "Times New Roman", Times, serif;
+  resize: none;
+  height: 100px;
+  padding-top: 4px;
+  font-size: 15px;
+}
+
 footer {
   background-color: #000;
   text-align: center;


### PR DESCRIPTION
In this branch I did: 

- When the page loads, the webapp the Involvement API shows the item likes and combines them with the data from the base API.

- When the user clicks on the Like button of an item (on Homepage), the interaction is recorded in the Involvement API and the screen is updated.

- Add All items Counter on the Home Page